### PR TITLE
Fix crawler to work with relative URLs

### DIFF
--- a/web/crawler/parser.ex
+++ b/web/crawler/parser.ex
@@ -1,7 +1,7 @@
 defmodule TokyoexHandsonDemo.Crawler.Parser do
   def parse_link(body, pattern \\ ~r//) do
     body
-    |> Floki.find("a[href^=http]")
+    |> Floki.find("a")
     |> Floki.attribute("href")
     |> Enum.filter(fn link ->
       Regex.match?(pattern, link)


### PR DESCRIPTION
クローラーが絶対パスでしか使えなかったので、相対パスでも使えるように修正しておきました。

もうちょっときれいな方法がありそうなので、もし何か思いついたら教えてください。
